### PR TITLE
Make `compress: true` option work

### DIFF
--- a/tasks/less.js
+++ b/tasks/less.js
@@ -21,7 +21,7 @@ module.exports = function(grunt) {
     var data = this.data;
 
     // initialize LESS parser
-    var parser = new(less.Parser);
+    var parser = new less.Parser();
 
     // make sure task runs until parser is completely finished (imports are processed asynchronously)
     var done = this.async();


### PR DESCRIPTION
- Passing `compress: true` to the `env` parser parameter doesn't minify the CSS output.
  Not sure if it's supposed to. Tested with less v1.3.0.
