### PR TITLE
Update LESS dependency from 1.2.1 to 1.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
     "grunt": "0.3.9",
 
     "rimraf": "1.0.9",
-    "less": "1.2.1",
+    "less": "1.3.0",
     "clean-css": "0.3.2",
     "requirejs": "1.0.7",
     "express": "2.5.4"


### PR DESCRIPTION
Fixes Twitter Bootstrap precompilation. Corresponding bootstrap issue [here](https://github.com/twitter/bootstrap/issues/2620).
