### PR TITLE
"list" task to accommodate "app" directory named differently.

### DIFF
--- a/tasks/requirejs.js
+++ b/tasks/requirejs.js
@@ -42,14 +42,17 @@ module.exports = function(grunt) {
   });
 
   grunt.registerTask("list", "Show module dependencies", function(prop) {
-    grunt.helper("list");
+    var options = grunt.config("requirejs") || {};
+    var baseUrl = options.baseUrl || "app";
+    // ensure trailing slash
+    grunt.helper("list", path.normalize(baseUrl + "/"));
   });
 
   grunt.registerHelper("r.js", function(options, done) {
     requirejs.optimize(options, done);
   });
 
-  grunt.registerHelper("list", function() {
+  grunt.registerHelper("list", function(appDir) {
     var jsRegExp = /\.js$/;
 
     requirejs.tools.useLib(function(require) {
@@ -71,13 +74,12 @@ module.exports = function(grunt) {
           });
         }
 
-        // Start with the app directory
-        recurse("app/");
+        // Start with the app directory e.g. app/
+        recurse(appDir);
 
         files.forEach(function(name) {
           var contents = fs.readFileSync(name, "utf8");
-          var prefix = process.platform === "win32" ? "app\\" : "app/";
-          var shortname = name.slice(name.indexOf(prefix));
+          var shortname = name.slice(name.indexOf(appDir));
 
           deps[shortname] = parse.findDependencies(name,
             contents);


### PR DESCRIPTION
First off, grunt-bbb has been a tremendous time saver and a treat to work with. Thank you very much for merging your hard-earned knowledge into this repo.

There are a couple areas I deviate from the boilerplate due to preference and environment. One is that I name my `app` directory `src` instead--I think it creates a clear contrast with the `dist` directory. I'd love to use the **list** task, but it is hard-coded to the `app` directory. In this fork, I've taken a crack at making it configurable by re-using the requirejs **baseUrl** configuration value when provided.

Please consider my idea (or pull request) for making the app dir configurable in the list task.
