### PR TITLE
Include Nib plugin path in stylus @import lookups

### DIFF
--- a/tasks/server.js
+++ b/tasks/server.js
@@ -78,7 +78,7 @@ module.exports = function(grunt) {
 
       fs.readFile(file, function(err, contents) {
         grunt.helper("stylus", contents.toString(), {
-          paths: ["assets/css/"]
+          paths: ["assets/css/", require("nib").path]
         }, function(css) {
           res.header("Content-type", "text/css");
           res.send(css);

--- a/tasks/styles.js
+++ b/tasks/styles.js
@@ -34,6 +34,12 @@ module.exports = function(grunt) {
       return log.write("No css imports defined.");
     }
 
+    if (!options.paths) {
+      options.paths = [];
+    }
+
+    options.paths.push(require("nib").path);
+
     // Iterate over the CSS rules, reducing to only @imports, then apply the
     // correct prefixed path to each file.  Finally, process each file and
     // concat into the output file.


### PR DESCRIPTION
In order to use the Nib plugin for Stylus, files must use the following
syntax:

```
@import 'nib';
```

This ensures that the proper Stylus directives will be included in those
files that request them.
