### PR TITLE
Adding handlebars compilations options support

### DIFF
--- a/tasks/handlebars.js
+++ b/tasks/handlebars.js
@@ -30,6 +30,10 @@ module.exports = function(grunt) {
   grunt.registerMultiTask("handlebars", "Compile handlebars templates and partials.", function() {
 
     var options = grunt.helper("options", this, {namespace: "JST"});
+    var handlebarsOptions ={};
+    if(!!this.data.handlebarsOptions){
+      handlebarsOptions=this.data.handlebarsOptions;
+    };
 
     grunt.verbose.writeflags(options, "Options");
 
@@ -56,7 +60,7 @@ module.exports = function(grunt) {
         src = grunt.file.read(file);
 
         try {
-          compiled = require("handlebars").precompile(src);
+          compiled = require("handlebars").precompile(src,handlebarsOptions);
           // if configured to, wrap template in Handlebars.template call
           if(options.wrapped) {
             compiled = "Handlebars.template("+compiled+")";


### PR DESCRIPTION
Some projects need to customize handlebars template precompilation. Now
it can be done by adding the configuration to the grunt.js file. For
example:

``` json
handlebars: {

        built: {
            src: ['app/templates/**/*.html'],
            dest: 'dist/debug/templates.js',
            handlebarsOptions:{
                    data: true,
                    stringParams: true
                }
          }

    }
```
