### PR TITLE
Removed query parameters from asset file paths so that using urlArgs works

### DIFF
--- a/tasks/server.js
+++ b/tasks/server.js
@@ -105,7 +105,9 @@ module.exports = function(grunt) {
     Object.keys(options.folders).sort().reverse().forEach(function(key) {
       site.get(root + key + "/*", function(req, res, next) {
         // Find filename.
-        var filename = req.url.slice((root + key).length);
+        var filename = req.url.slice((root + key).length)
+        // If there are query parameters, remove them.
+        filename = filename.split("?")[0];
 
         res.sendfile(path.join(options.folders[key] + filename));
       });


### PR DESCRIPTION
Without this change adding `urlArgs: "bust=" +  (new Date()).getTime(),` breaks RequireJS because the server matches the path but then includes the query parameters when attempting to fetch the file.
