### PR TITLE
Make sure server tasks responds 404 errors instead of index

### DIFF
--- a/tasks/server.js
+++ b/tasks/server.js
@@ -109,7 +109,11 @@ module.exports = function(grunt) {
         // If there are query parameters, remove them.
         filename = filename.split("?")[0];
 
-        res.sendfile(path.join(options.folders[key] + filename));
+        res.sendfile(path.join(options.folders[key] + filename), {}, function(err) {
+          if (err) {
+            res.send(404);
+          }
+        });
       });
     });
 
@@ -117,7 +121,11 @@ module.exports = function(grunt) {
     if (_.isObject(options.files)) {
       Object.keys(options.files).sort().reverse().forEach(function(key) {
         site.get(root + key, function(req, res) {
-          return res.sendfile(options.files[key]);
+          return res.sendfile(options.files[key], {}, function(err) {
+            if (err) {
+              res.send(404);
+            }
+          });
         });
       });
     }


### PR DESCRIPTION
Requesting a non-existent file in the static folders or non-existent file in the static files results in the index file getting served in the response instead of a 404. 

Just adds proper 404 response if necessary.
