### PR TITLE
Update tasks/server.js

### DIFF
--- a/tasks/server.js
+++ b/tasks/server.js
@@ -31,7 +31,7 @@ module.exports = function(grunt) {
       index: "./index.html",
 
       port: process.env.PORT || 8000,
-      host: process.env.HOST || "127.0.0.1"
+      host: process.env.HOST || "0.0.0.0"
     });
 
     options.folders = options.folders || {};


### PR DESCRIPTION
Change default host to 0.0.0.0, which allows machines on the same local network to access your BBB app by visiting your computer's IP. Useful for device and IE testing. The current default, 127.0.0.1, restricts connections to the local machine. 
